### PR TITLE
Fix YAML colour schemes to be Psych readable

### DIFF
--- a/resources/dark_bg.color_scheme.yaml
+++ b/resources/dark_bg.color_scheme.yaml
@@ -15,18 +15,44 @@
 #   :separator_bar  -> Separator displayed entries
 #   :name           -> Names from name : value pairs
 #   :value          -> Values from name : value pairs
----
-:normal:        [ :clear            ]
-:prompt:        [ :bold, :white     ]
-:header:        [ :bold, :yellow    ]
-:header_bar:    [ :blue             ]
-:line_number:   [ :bold, :white     ]
-:even_row:      [ :bold, :magenta   ]
-:odd_row:       [ :bold, :cyan      ]
-:information:   [ :bold, :green     ]
-:error:         [ :bold, :red       ]
-:private:       [ :bold, :red       ]
-:separator:     [ :bold, :white     ]
-:separator_bar: [ :bold, :blue      ]
-:name:          [ :bold, :blue      ]
-:value:         [ :bold, :cyan      ]
+--- 
+:normal: 
+- :clear
+:prompt: 
+- :bold
+- :white
+:header: 
+- :bold
+- :yellow
+:header_bar: 
+- :blue
+:line_number: 
+- :bold
+- :white
+:even_row: 
+- :bold
+- :magenta
+:odd_row: 
+- :bold
+- :cyan
+:information: 
+- :bold
+- :green
+:error: 
+- :bold
+- :red
+:private: 
+- :bold
+- :red
+:separator: 
+- :bold
+- :white
+:separator_bar: 
+- :bold
+- :blue
+:name: 
+- :bold
+- :blue
+:value: 
+- :bold
+- :cyan

--- a/resources/light_bg.color_scheme.yaml
+++ b/resources/light_bg.color_scheme.yaml
@@ -16,17 +16,35 @@
 #   :name           -> Names from name : value pairs
 #   :value          -> Values from name : value pairs
 ---
-:normal:        [ :clear    ]
-:prompt:        [ :red      ]
-:header:        [ :green    ]
-:header_bar:    [ :magenta  ]
-:line_number:   [ :cyan     ]
-:even_row:      [ :blue     ]
-:odd_row:       [ :red      ]
-:information:   [ :green    ]
-:error:         [ :bold, :yellow, :on_red ]
-:private:       [ :bold, :red, :on_black  ]
-:separator:     [ :cyan     ]
-:separator_bar: [ :green    ]
-:name:          [ :magenta  ]
-:value:         [ :blue     ]
+:normal: 
+- :clear
+:prompt: 
+- :red
+:header: 
+- :green
+:header_bar: 
+- :magenta
+:line_number: 
+- :cyan
+:even_row: 
+- :blue
+:odd_row: 
+- :red
+:information: 
+- :green
+:error: 
+- :bold
+- :yellow
+- :on_red
+:private: 
+- :bold
+- :red
+- :on_black
+:separator: 
+- :cyan
+:separator_bar: 
+- :green
+:name: 
+- :magenta
+:value: 
+- :blue


### PR DESCRIPTION
Trying to load originals with Psych:
[ytti@lintukoto ~]% pry -r yaml
[1] pry(main)> YAML.load_file "/home/ytti/tmp/keybox/resources/light_bg.color_scheme.yaml"
Psych::SyntaxError: (/home/ytti/tmp/keybox/resources/light_bg.color_scheme.yaml): did not find expected node content while parsing a flow node at line 19 column 19

Using 'Syck' same file works just fine. However in Ruby2.0 you cannot
switch to Sych anymore, but you have to use Psych.
